### PR TITLE
Adding functionality to auto select the latest, stable version of pyt…

### DIFF
--- a/python/mac-installs.sh
+++ b/python/mac-installs.sh
@@ -1,5 +1,16 @@
-PYTHON_VERSION=3.10
+# Define the Python download URL prefix
+PYTHON_DOWNLOAD_URL_PREFIX="https://www.python.org/ftp/python"
 
+# Fetch the list of available Python versions
+VERSION_LIST=$(curl -s "$PYTHON_DOWNLOAD_URL_PREFIX/" | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/")')
+
+# Filter out non-stable versions (e.g., alphas, betas, release candidates)
+STABLE_VERSIONS=$(echo "$VERSION_LIST" | grep -E '^[0-9]+\.[0-9]*[02468]\.[0-9]+$')
+
+# Get the latest stable version
+LATEST_STABLE_VERSION=$(echo "$STABLE_VERSIONS" | sort -V | tail -n 1)
+
+PYTHON_VERSION=$LATEST_STABLE_VERSION
 
 echo "Installing VS Code Extensions"
 code --install-extension ms-python.python --force

--- a/python/wsl-ubuntu-installs.sh
+++ b/python/wsl-ubuntu-installs.sh
@@ -1,4 +1,16 @@
-PYTHON_VERSION=3.12
+# Define the Python download URL prefix
+PYTHON_DOWNLOAD_URL_PREFIX="https://www.python.org/ftp/python"
+
+# Fetch the list of available Python versions
+VERSION_LIST=$(curl -s "$PYTHON_DOWNLOAD_URL_PREFIX/" | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/")')
+
+# Filter out non-stable versions (e.g., alphas, betas, release candidates)
+STABLE_VERSIONS=$(echo "$VERSION_LIST" | grep -E '^[0-9]+\.[0-9]*[02468]\.[0-9]+$')
+
+# Get the latest stable version
+LATEST_STABLE_VERSION=$(echo "$STABLE_VERSIONS" | sort -V | tail -n 1)
+
+PYTHON_VERSION=$LATEST_STABLE_VERSION
 
 echo "Installing VS Code Extensions"
 code --install-extension ms-python.python --force


### PR DESCRIPTION
…hon for installs

To test:
Create a test.sh file in any directory
Paste the requested changes into the file:
```bash
#!/bin/bash

# Define the Python download URL prefix
PYTHON_DOWNLOAD_URL_PREFIX="https://www.python.org/ftp/python"

# Fetch the list of available Python versions
VERSION_LIST=$(curl -s "$PYTHON_DOWNLOAD_URL_PREFIX/" | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/")')

# Filter out non-stable versions (e.g., alphas, betas, release candidates)
STABLE_VERSIONS=$(echo "$VERSION_LIST" | grep -E '^[0-9]+\.[0-9]*[02468]\.[0-9]+$')

# Get the latest stable version
LATEST_STABLE_VERSION=$(echo "$STABLE_VERSIONS" | sort -V | tail -n 1)

echo $LATEST_STABLE_VERSION
```
Change file permissions `chmod +x test.sh`
Run the file from the command line `./test.sh`

Expected result:
You should see the latest stable Python version number